### PR TITLE
Fix buttons in documentation:popover

### DIFF
--- a/src/popover/docs/demo.html
+++ b/src/popover/docs/demo.html
@@ -13,10 +13,12 @@
     
     <hr />
     <h4>Positional</h4>
-    <button popover-placement="top" popover="On the Top!" class="button">Top</button>
-    <button popover-placement="left" popover="On the Left!" class="button">Left</button>
-    <button popover-placement="right" popover="On the Right!" class="button">Right</button>
-    <button popover-placement="bottom" popover="On the Bottom!" class="button">Bottom</button>
+    <div>
+      <button popover-placement="top" popover="On the Top!" class="button">Top</button>
+      <button popover-placement="left" popover="On the Left!" class="button">Left</button>
+      <button popover-placement="right" popover="On the Right!" class="button">Right</button>
+      <button popover-placement="bottom" popover="On the Bottom!" class="button">Bottom</button>
+    </div>
     
     <hr />
     <h4>Triggers</h4>
@@ -27,6 +29,8 @@
 
     <hr />
     <h4>Other</h4>
-    <button Popover-animation="true" popover="I fade in and out!" class="button">fading</button>
-    <button popover="I have a title!" popover-title="The title." class="button">title</button>
+    <div>
+      <button Popover-animation="true" popover="I fade in and out!" class="button">fading</button>
+      <button popover="I have a title!" popover-title="The title." class="button">title</button>
+    </div>
 </div>


### PR DESCRIPTION
In the documentation, in the popover section, there's a little bug when we try the popover via buttons (Top, Left, Right, Bottom). The space between buttons is removed. This problem appear only on Chrome (I can't recreate it on Firefox and Safari).
The fix I found is to wrap buttons in a div.
