### PR TITLE
Add "vertical" class check to tabs-content element.

### DIFF
--- a/template/tabs/tabset.html
+++ b/template/tabs/tabset.html
@@ -1,6 +1,6 @@
 <div class="tabbable">
   <dl class="tabs" ng-class="{'vertical': vertical}" ng-transclude></dl>
-  <div class="tabs-content">
+  <div class="tabs-content" ng-class="{'vertical': vertical}">
     <div class="content" 
       ng-repeat="tab in tabs" 
       ng-class="{active: tab.active}">


### PR DESCRIPTION
Foundation requires "vertical" class on the tabs-content element in addition to the tabs element.
