### PR TITLE
Added missing package repo info

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "name": "angular-mm-foundation",
   "version": "0.3.0-SNAPSHOT",
   "homepage": "http://madmimi.github.io/angular-foundation/",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/madmimi/angular-foundation.git"
+  },
   "dependencies": {},
   "devDependencies": {
     "grunt": "~0.4.1",


### PR DESCRIPTION
We are using Foundation in our project and noticed this warning. This is because the `package.json` file is missing the required `repository` information. This pull request adds it in.

```
npm WARN package.json angular-mm-foundation@0.2.0-SNAPSHOT No repository field.
```

References:
- https://www.npmjs.org/doc/json.html
- http://stackoverflow.com/questions/16827858/npm-warn-package-json
- https://github.com/npm/npm/issues/3568
