### PR TITLE
fix(typeahead): Avoids potential $digest errors

### DIFF
--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -222,7 +222,9 @@ angular.module('mm.foundation.typeahead', ['mm.foundation.position', 'mm.foundat
         resetMatches();
 
         //return focus to the input element if a mach was selected via a mouse click event
-        element[0].focus();
+        $timeout(function(){
+            element[0].focus();
+        });
       };
 
       //bind keyboard events: arrows up(38) / down(40), enter(13) and tab(9), esc(27)


### PR DESCRIPTION
If another directive is bound to the focus event and calls $apply() in response to the focus() call inside the typeahead directive it leads to nasty "$digest is already in progress" errors. This fixes that problem.
