### PR TITLE
feat(dropdownToggle): added optional attribute for target element

### DIFF
--- a/src/dropdownToggle/dropdownToggle.js
+++ b/src/dropdownToggle/dropdownToggle.js
@@ -48,6 +48,11 @@ angular.module('mm.foundation.dropdownToggle', [ 'mm.foundation.position' ])
 
           openElement = element;
           closeMenu = function (event) {
+            if (dropdown.attr('dropdown-content') !== undefined && dropdown.attr('data-dropdown-content') !== 'false') {
+              if (dropdown.html().indexOf(event.target.outerHTML) > -1) {
+                return;
+              }
+            }
             $document.unbind('click', closeMenu);
             dropdown.css('display', 'none');
             closeMenu = angular.noop;


### PR DESCRIPTION
Adding the attribute `dropdown-content` to the target element of the dropdown will prevent any clicks within the dropdown from closing it. Useful for when you want to put something like a login form in the dropdown.
