### PR TITLE
fix(topbar) don't rely on scrollTop() for sticky

### DIFF
--- a/src/topbar/topbar.js
+++ b/src/topbar/topbar.js
@@ -111,10 +111,10 @@ angular.module("mm.foundation.topbar", [])
 
                     var distance = stickyoffset;
                     if (true) {
-                        if (win.scrollTop() > distance && !$class.hasClass('fixed')) {
+                        if ($window.scrollY > distance && !$class.hasClass('fixed')) {
                             $class.addClass('fixed');
                             body.css('padding-top', $scope.originalHeight + 'px');
-                        } else if (win.scrollTop() <= distance && $class.hasClass('fixed')) {
+                        } else if ($window.scrollY <= distance && $class.hasClass('fixed')) {
                             $class.removeClass('fixed');
                             body.css('padding-top', '');
                         }


### PR DESCRIPTION
When top bar is sticky:

```
<div class="sticky">
  <top-bar>...</top-bar>
</div>
```

All browsers will throw an `Uncaught TypeError: undefined is not a function` for `win.scrollTop()`.

This is caused by the fact that `scrollTop()` is not a native JS function but a jQuery function.  Instead, we should be using `$window.scrollY` which is supported cross browser (> IE8).
