### PR TITLE
fix(modal): refocus onto [autofocus] elements if any

### DIFF
--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -99,8 +99,15 @@ angular.module('mm.foundation.modal', ['mm.foundation.transition'])
         $timeout(function () {
           // trigger CSS transitions
           scope.animate = true;
-          // focus a freshly-opened modal
-          element[0].focus();
+
+          // If the modal contains any autofocus elements refocus onto the first one
+          if (element[0].querySelectorAll('[autofocus]').length > 0) {
+            element[0].querySelectorAll('[autofocus]')[0].focus();
+          }
+          else{
+          // otherwise focus the freshly-opened modal
+            element[0].focus();
+          }
         });
       }
     };


### PR DESCRIPTION
Opening a modal window using the directive causes autofocus elements inside the modal to lose focus. This refocuses them if any exist in the modal
