### PR TITLE
Fix modals with lengthy content

### DIFF
--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -83,7 +83,7 @@ angular.module('mm.foundation.modal', ['mm.foundation.transition'])
     };
   }])
 
-  .directive('modalWindow', ['$modalStack', '$timeout', function ($modalStack, $timeout) {
+  .directive('modalWindow', ['$modalStack', '$timeout', '$window', function ($modalStack, $timeout, $window) {
     return {
       restrict: 'EA',
       scope: {
@@ -95,10 +95,29 @@ angular.module('mm.foundation.modal', ['mm.foundation.transition'])
       templateUrl: 'template/modal/window.html',
       link: function (scope, element, attrs) {
         scope.windowClass = attrs.windowClass || '';
+        scope.modalClass = 'reveal-modal';
+
+        // Create a faux modal div just to measure its
+        // distance to top
+        var body = angular.element($window.document.body);
+        var faux = angular.element('<div class="' + scope.modalClass + '" style="z-index:-1""></div>');
+        body.append(faux[0]);
+        var marginTop = parseInt(getComputedStyle(faux[0]).top);
+        faux.remove();
+
+        var resize = function() {
+            var height = $window.innerHeight - (marginTop * 2);
+            element.css({
+                'max-height': height + 'px',
+                'overflow-y': 'auto'
+            });
+        }
 
         $timeout(function () {
           // trigger CSS transitions
           scope.animate = true;
+
+          resize();
 
           // If the modal contains any autofocus elements refocus onto the first one
           if (element[0].querySelectorAll('[autofocus]').length > 0) {
@@ -109,6 +128,8 @@ angular.module('mm.foundation.modal', ['mm.foundation.transition'])
             element[0].focus();
           }
         });
+
+        angular.element($window).bind('resize', resize);
       }
     };
   }])

--- a/template/modal/window.html
+++ b/template/modal/window.html
@@ -1,4 +1,4 @@
-<div tabindex="-1" class="reveal-modal fade {{ windowClass }}"
+<div tabindex="-1" class="{{ modalClass }} fade {{ windowClass }}"
   ng-class="{in: animate}" ng-click="close($event)"
   style="display: block; position: fixed; visibility: visible">
   <div ng-transclude></div>


### PR DESCRIPTION
Modals would grow out of the document window when a lot of content was added to it. This fix makes it scale in max-height.
It adds the same margin as found on top, to the bottom.

From:
![screen shot 2014-08-25 at 10 10 15](https://cloud.githubusercontent.com/assets/45449/4027483/68fd306e-2c2f-11e4-8a6e-095ae93164a6.png)

To:
![screen shot 2014-08-25 at 10 10 32](https://cloud.githubusercontent.com/assets/45449/4027482/68fa822e-2c2f-11e4-8b3b-98c661791cba.png)
