### PR TITLE
Enable modifying head based stylesheets

### DIFF
--- a/src/stylesheets/docs/readme.md
+++ b/src/stylesheets/docs/readme.md
@@ -1,0 +1,24 @@
+The `stylesheet` module lets you manipulate `<style>` DOM nodes easily. The module provides a `stylesheetFactory` that you can use to for example create new style tags:
+
+```js
+function(stylesheetFactory) {
+    var sheet = stylesheetFactory();
+    sheet.css('h1::before', {
+        'background-color': 'green',
+        color: 'red'
+    });
+
+    // Write changes to DOM
+    sheet.sync();
+
+    // Get the Angular Element
+    $sheet = sheet.element();
+};
+```
+
+`stylesheetFactory` takes either an *angular.element*, or null to create a new `style` element.
+A `stylesheet` provides the following API:
+
+* `css(selector, rules)` - Set or change rules for a given selector. *Selector* can be any arbitrary, valid CSS selector. *Rules* is an object of *rule*: *value*.
+* `sync()` - Syncs the sheet to the DOM. If the sheet is empty, the element will be removed from the DOM.
+* `element` - Get the angular.element

--- a/src/stylesheets/readme.md
+++ b/src/stylesheets/readme.md
@@ -1,0 +1,1 @@
+Stylesheets provides the `stylesheetFactory` helper to manipulate *<head>* based stylesheets. It'll allow you to easily inject a new stylesheet and give it a sensible API.

--- a/src/stylesheets/readme.md
+++ b/src/stylesheets/readme.md
@@ -1,1 +1,26 @@
 Stylesheets provides the `stylesheetFactory` helper to manipulate *<head>* based stylesheets. It'll allow you to easily inject a new stylesheet and give it a sensible API.
+
+```js
+function(stylesheetFactory) {
+	// Create a new stylesheet that is auto-appended to <head>
+	var sheet = stylesheetFactory();
+
+	// Or load an existing
+	var sheet = stylesheetFactory(
+		angular.element(document.querySelector('style#id')
+	);
+
+	sheet.css('foobar::before', {
+		'background-color': 'green',
+		color: 'red'
+		});
+
+	// Unset a value
+	sheet.css('foobar::before', { color: null });
+
+	sheet.sync();
+
+	// Get the element
+	var $elem = sheet.element();
+}
+```

--- a/src/stylesheets/stylesheets.js
+++ b/src/stylesheets/stylesheets.js
@@ -55,10 +55,12 @@ angular.module('mm.foundation.stylesheets', [])
             return exists ? rules[selector] : null;
           }
           if (!exists || content != rules[selector]) {
-            if (content === null)
+            if (content === null) {
               delete rules[selector];
-            else
+            }
+            else {
               rules[selector] = content;
+            }
           }
           return this;
         },

--- a/src/stylesheets/stylesheets.js
+++ b/src/stylesheets/stylesheets.js
@@ -3,11 +3,10 @@
  * @example:
 
     function(stylesheetFactory) {
-        var element = angular.element(document.head).find('styles');
-        stylesheetFactory(element).css('#myid:before', {
+        stylesheetFactory().css('#myid:before', {
             'background-color': 'red',
             width: '500px'
-        });
+        }).sync();
     }
  */
 angular.module('mm.foundation.stylesheets', [])

--- a/src/stylesheets/stylesheets.js
+++ b/src/stylesheets/stylesheets.js
@@ -1,0 +1,54 @@
+/*
+ * stylesheets - Manipulate sheets in style
+ * @example:
+
+    angular.module('mine', ['mm.foundation.stylesheets'])
+    .controller(function(stylesheetFactory) {
+        var element = angular.element(document.head).find('styles');
+        stylesheetFactory(element).css('#myid:before', {
+            'background-color': 'red',
+            width: '500px'
+        });
+    });
+ */
+angular.module('mm.foundation.stylesheets', [])
+
+.factory('stylesheetFactory', ['$document', function ($document) {
+    var rulesAsTextContent = function(rules) {
+        var textContent = '';
+        for (var selector in rules) {
+            var props = rules[selector];
+            textContent += selector + ' {\n';
+            for (var prop in props) {
+                textContent += '\t' + prop + ': ' + props[prop] + ';\n';
+            }
+            textContent += '}\n';
+        }
+        return textContent;
+    };
+    return function Stylesheet(element) {
+        if (!element) {
+            element = $document[0].createElement('style');
+            element = angular.element(element);
+            angular.element($document[0].querySelector('head')).append(element);
+        }
+        var write = function(textContent) {
+            element.html(textContent);
+        };
+
+        var rules = {};
+        return {
+            element: function() { return element; },
+            css: function(selector, content) {
+                if (selector in rules) {
+                    if (content == rules[selector]) {
+                        return;
+                    }
+                }
+                rules[selector] = content;
+                write(rulesAsTextContent(rules));
+                return this;
+            }
+        };
+    };
+}]);

--- a/src/stylesheets/stylesheets.js
+++ b/src/stylesheets/stylesheets.js
@@ -24,27 +24,45 @@ angular.module('mm.foundation.stylesheets', [])
         }
         return textContent.slice(0, -1);
     };
+    var head = $document[0].querySelector('head');
     return function Stylesheet(element) {
-      var $head = angular.element($document[0].querySelector('head'));
       if (!element) {
         element = $document[0].createElement('style');
-        element = angular.element(element);
       }
-      var currentContent = element.text();
       var write = function(textContent) {
-        if (textContent !== currentContent) {
-          currentContent = textContent;
-          element.text(textContent);
-          if (currentContent === '') {
-            element.remove();
-          }
-          else if (!$head[0].contains(element[0])) {
-            $head.append(element);
+        if (textContent === '') {
+          head.removeChild(element);
+          return true;
+        }
+        else if (textContent !== element.textContent) {
+          element.textContent = textContent;
+          if (!head.contains(element)) {
+            head.appendChild(element);
+            return true;
           }
         }
+        return false;
       };
 
       var rules = {};
+      var setRules = function(selector, content) {
+        if (content === null) {
+          delete rules[selector];
+        }
+        else {
+          if (!(selector in rules)) {
+            rules[selector] = {};
+          }
+          for (var _rule in content) {
+            if (content[_rule] === null) {
+              delete rules[selector][_rule];
+            }
+            else {
+              rules[selector][_rule] = content[_rule];
+            }
+          }
+        }
+      };
       return {
         element: function() { return element; },
         css: function(selector, content) {
@@ -53,17 +71,12 @@ angular.module('mm.foundation.stylesheets', [])
             return exists ? rules[selector] : null;
           }
           if (!exists || content != rules[selector]) {
-            if (content === null) {
-              delete rules[selector];
-            }
-            else {
-              rules[selector] = content;
-            }
+            setRules(selector, content);
           }
           return this;
         },
         sync: function() {
-          write(rulesAsTextContent(rules));
+          return write(rulesAsTextContent(rules));
         }
       };
     };

--- a/src/stylesheets/stylesheets.js
+++ b/src/stylesheets/stylesheets.js
@@ -2,14 +2,13 @@
  * stylesheets - Manipulate sheets in style
  * @example:
 
-    angular.module('mine', ['mm.foundation.stylesheets'])
-    .controller(function(stylesheetFactory) {
+    function(stylesheetFactory) {
         var element = angular.element(document.head).find('styles');
         stylesheetFactory(element).css('#myid:before', {
             'background-color': 'red',
             width: '500px'
         });
-    });
+    }
  */
 angular.module('mm.foundation.stylesheets', [])
 

--- a/src/stylesheets/test/stylesheets.spec.js
+++ b/src/stylesheets/test/stylesheets.spec.js
@@ -13,12 +13,30 @@ describe('stylesheets', function() {
 
   it('should create and inject new stylesheet', function() {
     var sheetId = 'stylesheets-test';
+    var selector = '#id:before';
+    var prop = 'color';
+    var value = 'red';
+
+    var content = {};
+    content[prop] = value;
+
     var sheet = stylesheetFactory();
-    sheet.css('#id:before', {color:'red'});
     sheet.element().attr('id', sheetId);
 
-    var $sheet = $document.find('#' + sheetId);
-    expect($sheet.text()).toEqual(sheet.element().text());
+    var cssEquals = function(expected) {
+      var $sheet = $document.find('#' + sheetId);
+      expect($sheet.text()).toEqual(expected);
+      expect(sheet.element().text()).toEqual(expected);
+    };
+
+    sheet.css(selector, content).sync();
+    cssEquals('#id:before {\n\tcolor: red;\n}');
+
+    content[prop] = 'green';
+    sheet.css(selector, content).sync();
+    cssEquals('#id:before {\n\tcolor: green;\n}');
+
+    sheet.css(selector, null).sync();
+    cssEquals('');
   });
 });
-

--- a/src/stylesheets/test/stylesheets.spec.js
+++ b/src/stylesheets/test/stylesheets.spec.js
@@ -46,11 +46,9 @@ describe('stylesheets', function() {
     $style.text('body{color:green;}');
     angular.element($document[0].querySelector('head')).append($style);
 
-    var sheet = stylesheetFactory($style[0]);
-    sheet.css('body', null).sync();
+    stylesheetFactory($style[0]).css('body', null).sync();
 
     // Test if sheet is removed from dom
-    var sheet = $document[0].querySelector('#' + sheetId);
-    expect(sheet).toEqual(null);
+    expect($document[0].querySelector('#' + sheetId)).toEqual(null);
   });
 });

--- a/src/stylesheets/test/stylesheets.spec.js
+++ b/src/stylesheets/test/stylesheets.spec.js
@@ -1,0 +1,24 @@
+describe('stylesheets', function() {
+  var $compile, $rootScope, $document, stylesheetFactory;
+
+  beforeEach(module('mm.foundation.stylesheets'));
+
+  beforeEach(inject(function(_$compile_, _$rootScope_, _$document_, _stylesheetFactory_) {
+    $compile = _$compile_;
+    $rootScope = _$rootScope_;
+    $document = _$document_;
+    stylesheetFactory = _stylesheetFactory_;
+    $scope = $rootScope.$new();
+  }));
+
+  it('should create and inject new stylesheet', function() {
+    var sheetId = 'stylesheets-test';
+    var sheet = stylesheetFactory();
+    sheet.css('#id:before', {color:'red'});
+    sheet.element().attr('id', sheetId);
+
+    var $sheet = $document.find('#' + sheetId);
+    expect($sheet.text()).toEqual(sheet.element().text());
+  });
+});
+

--- a/src/stylesheets/test/stylesheets.spec.js
+++ b/src/stylesheets/test/stylesheets.spec.js
@@ -13,7 +13,7 @@ describe('stylesheets', function() {
 
   it('should create and inject new stylesheet', function() {
     var sheetId = 'stylesheets-test';
-    var selector = '#id:before';
+    var selector = '#id::before';
     var prop = 'color';
     var value = 'red';
 
@@ -30,11 +30,11 @@ describe('stylesheets', function() {
     };
 
     sheet.css(selector, content).sync();
-    cssEquals('#id:before {\n\tcolor: red;\n}');
+    cssEquals('#id::before {\n\tcolor: red;\n}');
 
     content[prop] = 'green';
     sheet.css(selector, content).sync();
-    cssEquals('#id:before {\n\tcolor: green;\n}');
+    cssEquals('#id::before {\n\tcolor: green;\n}');
 
     sheet.css(selector, null).sync();
     cssEquals('');

--- a/src/stylesheets/test/stylesheets.spec.js
+++ b/src/stylesheets/test/stylesheets.spec.js
@@ -11,6 +11,13 @@ describe('stylesheets', function() {
     $scope = $rootScope.$new();
   }));
 
+  var cssEquals = function(sheet, expected) {
+    var el = sheet.element();
+    var _sheet = $document[0].querySelector('#' + el.id);
+    expect(_sheet.textContent).toEqual(expected);
+    expect(el.textContent).toEqual(expected);
+  };
+
   it('should create and inject new stylesheet', function() {
     var sheetId = 'stylesheets-test';
     var selector = '#id::before';
@@ -21,22 +28,29 @@ describe('stylesheets', function() {
     content[prop] = value;
 
     var sheet = stylesheetFactory();
-    sheet.element().attr('id', sheetId);
-
-    var cssEquals = function(expected) {
-      var $sheet = $document.find('#' + sheetId);
-      expect($sheet.text()).toEqual(expected);
-      expect(sheet.element().text()).toEqual(expected);
-    };
+    sheet.element().id = sheetId;
 
     sheet.css(selector, content).sync();
-    cssEquals('#id::before {\n\tcolor: red;\n}');
+    cssEquals(sheet, '#id::before {\n\tcolor: red;\n}');
 
     content[prop] = 'green';
     sheet.css(selector, content).sync();
-    cssEquals('#id::before {\n\tcolor: green;\n}');
+    cssEquals(sheet, '#id::before {\n\tcolor: green;\n}');
+  });
 
-    sheet.css(selector, null).sync();
-    cssEquals('');
+  it('should detach when syncing empty sheet', function() {
+    var sheetId = 'stylesheets-empty';
+
+    var $style = angular.element($document[0].createElement('style'));
+    $style.attr('id', sheetId);
+    $style.text('body{color:green;}');
+    angular.element($document[0].querySelector('head')).append($style);
+
+    var sheet = stylesheetFactory($style[0]);
+    sheet.css('body', null).sync();
+
+    // Test if sheet is removed from dom
+    var sheet = $document[0].querySelector('#' + sheetId);
+    expect(sheet).toEqual(null);
   });
 });


### PR DESCRIPTION
Some changes I'm looking into requires creating and modifying `head` based `style` tags because foundation uses **:before** and **:after** pseudo selectors.
Currently I'm looking into fixing the `dropdownToggle`'s _pip_ positioning relative to the initiating element.

I'm looking to create an API that is lightweight and feels familiar, hence the single `css` method to set/update/delete properties in the sheet.
The sheet itself is synced into/out of the DOM by calling the `sync` method and this will remove the element entirely if no content is found.

``` js
function(stylesheetFactory) {
  // Create a new stylesheet that is auto-appended to <head>
  var sheet = stylesheetFactory();
  // Or load an existing
  var sheet = stylesheetFactory(angular.element(document.querySelector('style#id'));

  sheet.css('foobar::before', {
    'background-color': 'green',
    color: 'red'
  });

  // Unset a value
  sheet.css('foobar::before', { color: null });

  sheet.sync();

  // Get the element
  var $elem = sheet.element();
}
```
