### PR TITLE
fix(modal): Destroy modal scope in removeModalWindow()

### DIFF
--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -140,7 +140,6 @@ angular.module('mm.foundation.modal', ['mm.foundation.transition'])
       });
 
       function removeModalWindow(modalInstance) {
-
         var body = $document.find('body').eq(0);
         var modalWindow = openedWindows.get(modalInstance).value;
 
@@ -148,8 +147,11 @@ angular.module('mm.foundation.modal', ['mm.foundation.transition'])
         openedWindows.remove(modalInstance);
 
         //remove window DOM element
-        removeAfterAnimate(modalWindow.modalDomEl, modalWindow.modalScope, 300, checkRemoveBackdrop);
-        body.toggleClass(OPENED_MODAL_CLASS, openedWindows.length() > 0);
+        removeAfterAnimate(modalWindow.modalDomEl, modalWindow.modalScope, 300, function() {
+          modalWindow.modalScope.$destroy();
+          body.toggleClass(OPENED_MODAL_CLASS, openedWindows.length() > 0);
+          checkRemoveBackdrop();
+        });
       }
 
       function checkRemoveBackdrop() {
@@ -228,7 +230,7 @@ angular.module('mm.foundation.modal', ['mm.foundation.transition'])
           backdropDomEl = $compile('<div modal-backdrop></div>')(backdropScope);
           body.append(backdropDomEl);
         }
-          
+
         // Create a faux modal div just to measure its
         // distance to top
         var faux = angular.element('<div class="reveal-modal" style="z-index:-1""></div>');

--- a/src/modal/test/modal.spec.js
+++ b/src/modal/test/modal.spec.js
@@ -207,6 +207,19 @@ describe('$modal', function () {
       expect(modal.opened).toBeRejectedWith(false);
     });
 
+    it('should destroy modal scope on close', function () {
+      expect($rootScope.$$childTail).toEqual(null);
+
+      var modal = open({template: '<div>Content</div>'});
+      expect($rootScope.$$childTail).toNotEqual(null);
+
+      close(modal, 'closed ok');
+      waitForBackdropAnimation();
+      expect($document).toHaveModalsOpen(0);
+
+      $timeout.flush();
+      expect($rootScope.$$childTail).toEqual(null);
+    });
   });
 
   describe('default options can be changed in a provider', function () {


### PR DESCRIPTION
Fix for issue #138
Test case included
