### PR TITLE
feat(events): add close & dismiss events with preventDefault

### DIFF
--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -253,18 +253,29 @@ angular.module('mm.foundation.modal', ['mm.foundation.transition'])
       };
 
       $modalStack.close = function (modalInstance, result) {
-        var modalWindow = openedWindows.get(modalInstance).value;
-        if (modalWindow) {
+        var modalWindow = openedWindows.get(modalInstance).value,
+            scope = modalWindow.modalScope,
+            evt = scope.$broadcast('close:modal:fndtn', modalWindow);
+
+        if (modalWindow && !evt.defaultPrevented) {
           modalWindow.deferred.resolve(result);
           removeModalWindow(modalInstance);
+
+          scope.$broadcast('closed:modal:fndtn', modalWindow);
         }
       };
 
       $modalStack.dismiss = function (modalInstance, reason) {
-        var modalWindow = openedWindows.get(modalInstance).value;
-        if (modalWindow) {
+
+        var modalWindow = openedWindows.get(modalInstance).value,
+            scope = modalWindow.modalScope,
+            evt = scope.$broadcast('dismiss:modal:fndtn', modalWindow);
+
+        if (modalWindow && !evt.defaultPrevented) {
           modalWindow.deferred.reject(reason);
           removeModalWindow(modalInstance);
+
+          scope.$broadcast('dismissed:modal:fndtn', modalWindow);
         }
       };
 

--- a/src/modal/test/modal.spec.js
+++ b/src/modal/test/modal.spec.js
@@ -511,4 +511,33 @@ describe('$modal', function () {
       expect(body).not.toHaveClass('modal-open');
     });
   });
+
+  describe('events', function () {
+    it('should not close modal if defaultPrevented', function () {
+      var TestCtrl = function($scope, $modalInstance) {
+        $scope.$on('close:modal:fndtn', function (event) {
+          event.preventDefault();
+        });
+      };
+
+      var modal = open({template: '<div>defaultPrevented</div>', controller: TestCtrl});
+
+      close(modal, 'close');
+
+      expect($document).toHaveModalOpenWithContent('defaultPrevented', 'div');
+    });
+    it('should not dismiss modal if defaultPrevented', function () {
+      var TestCtrl = function($scope, $modalInstance) {
+        $scope.$on('dismiss:modal:fndtn', function (event) {
+          event.preventDefault();
+        });
+      };
+
+      var modal = open({template: '<div>defaultPrevented</div>', controller: TestCtrl});
+
+      close(modal, 'close');
+
+      expect($document).toHaveModalOpenWithContent('defaultPrevented', 'div');
+    });
+  });
 });


### PR DESCRIPTION
Recently I needed a way to prevent a modal from closing. I could do a method in the scope but couldn't control backdrop or `ESC` key.

I want to introduce events with preventDefault capabilities so this kind of behavior can be controlled without much "hackery".

I propose naming these events, as you can see in the code, with the following structure:
`action:module:fndtn'

If you are interested please let me know so I can open an issue and propose which events could be beneficial and add them if you want.
