### PR TITLE
Add 'expanded' class to active dropdown-toggle 

### DIFF
--- a/src/dropdownToggle/dropdownToggle.js
+++ b/src/dropdownToggle/dropdownToggle.js
@@ -74,6 +74,7 @@ angular.module('mm.foundation.dropdownToggle', [ 'mm.foundation.position', 'mm.f
           }
 
           dropdown.css(css);
+          element.addClass('expanded');
 
           if (parentHasDropdown()) {
             parent.addClass('hover');
@@ -84,6 +85,7 @@ angular.module('mm.foundation.dropdownToggle', [ 'mm.foundation.position', 'mm.f
           closeMenu = function (event) {
             $document.off('click', closeMenu);
             dropdown.css('display', 'none');
+            element.removeClass('expanded');
             closeMenu = angular.noop;
             openElement = null;
             if (parent.hasClass('hover')) {


### PR DESCRIPTION
Foundation adds an aria-expanded="true" on dropdown-toggles that have been activated. I often use this as a styling hook, but angular-foundation seemed to lack any such state indication.

I wasn't sure if there is a reason why aria roles are not being used so I went with a safe classname which should not collide with default Foundation CSS.