### PR TITLE
dropdownToggle: uses parentOffset instead of window width + close on horizontal window resize

### DIFF
--- a/src/dropdownToggle/dropdownToggle.js
+++ b/src/dropdownToggle/dropdownToggle.js
@@ -36,6 +36,8 @@ angular.module('mm.foundation.dropdownToggle', [ 'mm.foundation.position', 'mm.f
       };
 
       var onClick = function (event) {
+        var windowWidth = $window.innerWidth;
+
         dropdown = angular.element($document[0].querySelector(scope.dropdownToggle));
         var elementWasOpen = (element === openElement);
 
@@ -90,7 +92,11 @@ angular.module('mm.foundation.dropdownToggle', [ 'mm.foundation.position', 'mm.f
           openElement = element;
 
           closeMenu = function (event) {
+            if (event && event.type == 'resize' && event.target.innerWidth == windowWidth) {
+              return;
+            }
             $document.off('click', closeMenu);
+            angular.element($window).unbind('resize', closeMenu);
             dropdown.css('display', 'none');
             closeMenu = angular.noop;
             openElement = null;
@@ -99,6 +105,7 @@ angular.module('mm.foundation.dropdownToggle', [ 'mm.foundation.position', 'mm.f
             }
           };
           $document.on('click', closeMenu);
+          angular.element($window).bind('resize', closeMenu);
         }
       };
 

--- a/src/dropdownToggle/dropdownToggle.js
+++ b/src/dropdownToggle/dropdownToggle.js
@@ -50,27 +50,35 @@ angular.module('mm.foundation.dropdownToggle', [ 'mm.foundation.position', 'mm.f
           dropdown.css('display', 'block'); // We display the element so that offsetParent is populated
           var offset = $position.offset(element);
           var parentOffset = $position.offset(angular.element(dropdown[0].offsetParent));
-          var dropdownWidth = dropdown.prop('offsetWidth');
           var css = {
             top: offset.top - parentOffset.top + offset.height + 'px'
           };
 
           if (controller.small()) {
-            css.left = Math.max((parentOffset.width - dropdownWidth) / 2, 8) + 'px';
             css.position = 'absolute';
             css.width = '95%';
             css['max-width'] = 'none';
           }
+          else
+          {
+            css.width = '';
+            css.position = '';
+            css['max-width'] = '';
+          }
+          dropdown.css(css);
+          var dropdownWidth = dropdown.prop('offsetWidth');
+
+          if (controller.small()) {
+            css.left = Math.max((parentOffset.width - dropdownWidth) / 2, 8) + 'px';
+          }
           else {
             var left = Math.round(offset.left - parentOffset.left);
-            var rightThreshold = $window.innerWidth - dropdownWidth - 8;
+            var rightThreshold = dropdown[0].offsetParent.offsetWidth - dropdownWidth - 8;
             if (left > rightThreshold) {
                 left = rightThreshold;
                 dropdown.removeClass('left').addClass('right');
             }
             css.left = left + 'px';
-            css.position = null;
-            css['max-width'] = null;
           }
 
           dropdown.css(css);


### PR DESCRIPTION
I notices some issues when changing window size with dropdown.
The original behaviour is to check if controller is small or not, but if the value changes from small -> !small, the dropdown had a different width.
The reason is because jquery.css() needs an empty string to reset css value (and not null values).

Secondly, dropdownWidth was calculated before the mediaQuery check... so if controller was small, width is the old value (95% of container).
I think it could be improved by removing some css calls, but the new behaviour is correct.

Then, i added a windows resize listener to close dropdown if windows is resized (since it can cause mediaQuery to changer).
But i filtered this to only horizontal resize, because on some devices, vertical resize can happen (toolbar appearing) when scrolling.

I was not able to write 2 tests: 'closes on window horizontal resize', and 'not closes on windows vertical resize', because $windows.resizeBy(deltaX, deltaY) works only for popups.
If anyone know how to trigger a custom resize event, don't hesitate to write those 2 missing tests.
