### PR TITLE
Fixed initialization of active tab.

### DIFF
--- a/src/tabs/tabs.js
+++ b/src/tabs/tabs.js
@@ -183,30 +183,20 @@ angular.module('mm.foundation.tabs', [])
     },
     compile: function(elm, attrs, transclude) {
       return function postLink(scope, elm, attrs, tabsetCtrl) {
-        var getActive, setActive;
+        //if we've provided an active in attrs
+        //we're initializing which tab is selected
+        //once we use it once to initialize scope.active we don't
+        //want to watch it anymore or use it in overriding the selection
+        //behavior of end-users.
+        var getActive;
+
         if (attrs.active) {
           getActive = $parse(attrs.active);
-          setActive = getActive.assign;
-          scope.$parent.$watch(getActive, function updateActive(value, oldVal) {
-            // Avoid re-initializing scope.active as it is already initialized
-            // below. (watcher is called async during init with value ===
-            // oldVal)
-            if (value !== oldVal) {
-              scope.active = !!value;
-            }
-          });
           scope.active = getActive(scope.$parent);
-        } else {
-          setActive = getActive = angular.noop;
         }
 
         scope.$watch('active', function(active) {
-          if( !angular.isFunction(setActive) ){
-            return;
-          }
-          // Note this watcher also initializes and assigns scope.active to the
-          // attrs.active expression.          
-          setActive(scope.$parent, active);
+
           if (active) {
             tabsetCtrl.select(scope);
             scope.onSelect();

--- a/src/tabs/tabs.js
+++ b/src/tabs/tabs.js
@@ -193,7 +193,9 @@ angular.module('mm.foundation.tabs', [])
         if (attrs.active) {
           getActive = $parse(attrs.active);
           scope.active = getActive(scope.$parent);
-        }
+        } else {
+-          setActive = getActive = angular.noop;
+         }
 
         scope.$watch('active', function(active) {
 


### PR DESCRIPTION
The getActive/setActive code previously overwrote any user actions associated with clicking tabs w/ the initial "active" attr value(s).

Now, attrs.active is truely used to initialize only.