### PR TITLE
fix(modal): Fix modal window focus

### DIFF
--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -106,7 +106,7 @@ angular.module('mm.foundation.modal', ['mm.foundation.transition'])
           }
           else{
           // otherwise focus the freshly-opened modal
-            element[0].querySelector('div').focus();
+            element[0].focus();
           }
         });
       }


### PR DESCRIPTION
Focus was not being given to modal because it was being called on a div with no tabindex. Fixed by calling focus method on the outermost modal itself, which already has tabindex.