### PR TITLE
Fix Typeahead focus out

### DIFF
--- a/src/typeahead/test/typeahead.spec.js
+++ b/src/typeahead/test/typeahead.spec.js
@@ -528,6 +528,45 @@ describe('typeahead tests', function () {
       expect($scope.isLoading).toBeFalsy();
     });
 
+    it('should update loading callback when input loses focus', function() {
+      $scope.isLoading = false;
+      $scope.items = function(viewValue) {
+        return $timeout(function() {
+          return [viewValue];
+        });
+      };
+
+      var element = prepareInputEl("<div><input ng-model='result' typeahead='item for item in items($viewValue)' typeahead-loading='isLoading'></div>");
+      changeInputValueTo(element, 'foo');
+
+      expect($scope.isLoading).toBeTruthy();
+
+      findInput(element).blur();
+      $timeout.flush();
+
+      expect($scope.isLoading).toBeFalsy();
+    });
+
+    it('should update loading callback when promise is rejected', inject(function($q) {
+      var element, deferred;
+
+      deferred = $q.defer();
+      $scope.isLoading = false;
+      $scope.items = function(viewValue) {
+        return deferred.promise;
+      };
+
+      element = prepareInputEl("<div><input ng-model='result' typeahead='item for item in items($viewValue)' typeahead-loading='isLoading'></div>");
+      changeInputValueTo(element, 'foo');
+
+      expect($scope.isLoading).toBeTruthy();
+
+      deferred.reject(['bar']);
+      $timeout.flush();
+
+      expect($scope.isLoading).toBeFalsy();
+    }));
+
     it('does not close matches popup on click in input', function () {
       var element = prepareInputEl("<div><input ng-model='result' typeahead='item for item in source | filter:$viewValue'></div>");
       var inputEl = findInput(element);

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -128,10 +128,10 @@ angular.module('mm.foundation.typeahead', ['mm.foundation.position', 'mm.foundat
             } else {
               resetMatches();
             }
-            isLoadingSetter(originalScope, false);
           }
         }, function(){
           resetMatches();
+        }).finally(function() {
           isLoadingSetter(originalScope, false);
         });
       };


### PR DESCRIPTION
Hey guys!

I found a bug on the typeahead directive: it's not updating the loading callback if the input field loses focus. You can test it on http://plnkr.co/edit/VZOjJLO4nZ5HMWXrl9Wc?p=preview, just type something and immediately focus out. I just changed when the directive updates the loading callback and it's working. :smile: 