### PR TITLE
Fix '$destroy' listener in dropdownToggle

### DIFF
--- a/src/dropdownToggle/dropdownToggle.js
+++ b/src/dropdownToggle/dropdownToggle.js
@@ -103,7 +103,7 @@ angular.module('mm.foundation.dropdownToggle', [ 'mm.foundation.position', 'mm.f
       scope.$watch('$location.path', function() { closeMenu(); });
 
       element.on('click', onClick);
-      element.on('$destroy', function() {
+      scope.$on('$destroy', function() {
         element.off('click', onClick);
       });
     }


### PR DESCRIPTION
The '$destroy' event should be listened for on the scope, not on the DOM element.