### PR TITLE
Fixed that alert is always "closeable" due to change in angularjs 1.4

### DIFF
--- a/src/alert/alert.js
+++ b/src/alert/alert.js
@@ -1,7 +1,7 @@
 angular.module("mm.foundation.alert", [])
 
 .controller('AlertController', ['$scope', '$attrs', function ($scope, $attrs) {
-  $scope.closeable = 'close' in $attrs;
+  $scope.closeable = 'close' in $attrs && typeof $attrs.close !== "undefined";
 }])
 
 .directive('alert', function () {


### PR DESCRIPTION
See https://github.com/pineconellc/angular-foundation/issues/242 and angular/angular.js@6a38dbf