### PR TITLE
feat(rating): backport from angular-ui/bootstrap, now using `ngModel`

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -9,7 +9,7 @@ module.exports = function(grunt) {
 
   grunt.initConfig({
     ngversion: '1.3.3',
-    fdversion: '5.2.0',
+    fdversion: '5.5.2',
     faversion: '4.2.0',
     modules: [],//to be filled in by build task
     pkg: grunt.file.readJSON('package.json'),

--- a/src/rating/docs/demo.html
+++ b/src/rating/docs/demo.html
@@ -1,21 +1,15 @@
 <div ng-controller="RatingDemoCtrl">
     <h4>Default</h4>
-    <rating value="rate" max="max" readonly="isReadonly" on-hover="hoveringOver(value)" on-leave="overStar = null"></rating>
+    <rating ng-model="rate" max="max" readonly="isReadonly" on-hover="hoveringOver(value)" on-leave="overStar = null" titles="['one','two','three']" ></rating>
     <span class="label" ng-class="{'label-warning': percent<30, 'label-info': percent>=30 && percent<70, 'label-success': percent>=70}" ng-show="overStar && !isReadonly">{{percent}}%</span>
 
     <pre style="margin:15px 0;">Rate: <b>{{rate}}</b> - Readonly is: <i>{{isReadonly}}</i> - Hovering over: <b>{{overStar || "none"}}</b></pre>
 
-    <button class="button small alert" ng-click="rate = 0" ng-disabled="isReadonly">Clear</button>
-    <button class="button small" ng-click="isReadonly = ! isReadonly">Toggle Readonly</button>
+    <button type="button" class="button small alert" ng-click="rate = 0" ng-disabled="isReadonly">Clear</button>
+    <button type="button" class="button small" ng-click="isReadonly = ! isReadonly">Toggle Readonly</button>
     <hr />
 
     <h4>Custom icons</h4>
-    <div ng-init="x = 5">
-      <rating value="x" max="15" state-on="'fa-check-circle'" state-off="'fa-check-circle-o'"></rating>
-      <b>(<i>Rate:</i> {{x}})</b>
-    </div>
-    <div ng-init="y = 2">
-      <rating value="y" rating-states="ratingStates"></rating>
-      <b>(<i>Rate:</i> {{y}})</b>
-    </div>
+    <div ng-init="x = 5"><rating ng-model="x" max="15" state-on="'fa-check-circle'" state-off="'fa-check-circle-o'"></rating> <b>(<i>Rate:</i> {{x}})</b></div>
+    <div ng-init="y = 2"><rating ng-model="y" rating-states="ratingStates"></rating> <b>(<i>Rate:</i> {{y}})</b></div>
 </div>

--- a/src/rating/docs/readme.md
+++ b/src/rating/docs/readme.md
@@ -6,7 +6,7 @@ It uses Font Awesome icons (http://fontawesome.io/) by default.
 
 #### `<rating>` ####
 
- * `value` <i class="fa fa-eye"></i>
+ * `ng-model` <i class="fa fa-eye"></i>
  	:
  	The current rate.
 
@@ -14,9 +14,13 @@ It uses Font Awesome icons (http://fontawesome.io/) by default.
  	_(Defaults: 5)_ :
  	Changes the number of icons.
 
- * `readonly`
+ * `readonly` <i class="fa fa-eye"></i>
  	_(Defaults: false)_ :
  	Prevent user's interaction.
+
+ * `titles`
+ 	_(Defaults: ["one", "two", "three", "four", "five"])_ :
+ 	An array of Strings defining titles for all icons
 
  * `on-hover(value)`
  	:

--- a/src/rating/test/rating.spec.js
+++ b/src/rating/test/rating.spec.js
@@ -1,12 +1,12 @@
-describe('rating directive', function () {
-  var $rootScope, element;
+describe('rating directive', function() {
+  var $rootScope, $compile, element;
   beforeEach(module('mm.foundation.rating'));
   beforeEach(module('template/rating/rating.html'));
   beforeEach(inject(function(_$compile_, _$rootScope_) {
     $compile = _$compile_;
     $rootScope = _$rootScope_;
     $rootScope.rate = 3;
-    element = $compile('<rating value="rate"></rating>')($rootScope);
+    element = $compile('<rating ng-model="rate"></rating>')($rootScope);
     $rootScope.$digest();
   }));
 
@@ -27,12 +27,27 @@ describe('rating directive', function () {
     return state;
   }
 
+  function getTitles() {
+    var stars = getStars();
+    return stars.toArray().map(function(star) {
+      return angular.element(star).attr('title');
+    });
+  }
+
+  function triggerKeyDown(keyCode) {
+    var e = $.Event('keydown');
+    e.which = keyCode;
+    element.trigger(e);
+  }
+
   it('contains the default number of icons', function() {
     expect(getStars().length).toBe(5);
+    expect(element.attr('aria-valuemax')).toBe('5');
   });
 
   it('initializes the default star icons as selected', function() {
     expect(getState()).toEqual([true, true, true, false, false]);
+    expect(element.attr('aria-valuenow')).toBe('3');
   });
 
   it('handles correctly the click event', function() {
@@ -40,11 +55,19 @@ describe('rating directive', function () {
     $rootScope.$digest();
     expect(getState()).toEqual([true, true, false, false, false]);
     expect($rootScope.rate).toBe(2);
+    expect(element.attr('aria-valuenow')).toBe('2');
 
     getStar(5).click();
     $rootScope.$digest();
     expect(getState()).toEqual([true, true, true, true, true]);
     expect($rootScope.rate).toBe(5);
+    expect(element.attr('aria-valuenow')).toBe('5');
+
+    getStar(5).click();
+    $rootScope.$digest();
+    expect(getState()).toEqual([false, false, false, false, false]);
+    expect($rootScope.rate).toBe(0);
+    expect(element.attr('aria-valuenow')).toBe('0');
   });
 
   it('handles correctly the hover event', function() {
@@ -63,30 +86,47 @@ describe('rating directive', function () {
     expect($rootScope.rate).toBe(3);
   });
 
+  it('rounds off the number of stars shown with decimal values', function() {
+    $rootScope.rate = 2.1;
+    $rootScope.$digest();
+
+    expect(getState()).toEqual([true, true, false, false, false]);
+    expect(element.attr('aria-valuenow')).toBe('2');
+
+    $rootScope.rate = 2.5;
+    $rootScope.$digest();
+
+    expect(getState()).toEqual([true, true, true, false, false]);
+    expect(element.attr('aria-valuenow')).toBe('3');
+  });
+
   it('changes the number of selected icons when value changes', function() {
     $rootScope.rate = 2;
     $rootScope.$digest();
 
     expect(getState()).toEqual([true, true, false, false, false]);
+    expect(element.attr('aria-valuenow')).toBe('2');
   });
 
   it('shows different number of icons when `max` attribute is set', function() {
-    element = $compile('<rating value="rate" max="7"></rating>')($rootScope);
+    element = $compile('<rating ng-model="rate" max="7"></rating>')($rootScope);
     $rootScope.$digest();
 
     expect(getStars().length).toBe(7);
+    expect(element.attr('aria-valuemax')).toBe('7');
   });
 
   it('shows different number of icons when `max` attribute is from scope variable', function() {
     $rootScope.max = 15;
-    element = $compile('<rating value="rate" max="max"></rating>')($rootScope);
+    element = $compile('<rating ng-model="rate" max="max"></rating>')($rootScope);
     $rootScope.$digest();
     expect(getStars().length).toBe(15);
+    expect(element.attr('aria-valuemax')).toBe('15');
   });
 
   it('handles readonly attribute', function() {
     $rootScope.isReadonly = true;
-    element = $compile('<rating value="rate" readonly="isReadonly"></rating>')($rootScope);
+    element = $compile('<rating ng-model="rate" readonly="isReadonly"></rating>')($rootScope);
     $rootScope.$digest();
 
     expect(getState()).toEqual([true, true, true, false, false]);
@@ -106,7 +146,7 @@ describe('rating directive', function () {
 
   it('should fire onHover', function() {
     $rootScope.hoveringOver = jasmine.createSpy('hoveringOver');
-    element = $compile('<rating value="rate" on-hover="hoveringOver(value)"></rating>')($rootScope);
+    element = $compile('<rating ng-model="rate" on-hover="hoveringOver(value)"></rating>')($rootScope);
     $rootScope.$digest();
 
     getStar(3).trigger('mouseover');
@@ -116,7 +156,7 @@ describe('rating directive', function () {
 
   it('should fire onLeave', function() {
     $rootScope.leaving = jasmine.createSpy('leaving');
-    element = $compile('<rating value="rate" on-leave="leaving()"></rating>')($rootScope);
+    element = $compile('<rating ng-model="rate" on-leave="leaving()"></rating>')($rootScope);
     $rootScope.$digest();
 
     element.trigger('mouseleave');
@@ -124,11 +164,59 @@ describe('rating directive', function () {
     expect($rootScope.leaving).toHaveBeenCalled();
   });
 
+  describe('keyboard navigation', function() {
+    it('supports arrow keys', function() {
+      triggerKeyDown(38);
+      expect($rootScope.rate).toBe(4);
+
+      triggerKeyDown(37);
+      expect($rootScope.rate).toBe(3);
+      triggerKeyDown(40);
+      expect($rootScope.rate).toBe(2);
+
+      triggerKeyDown(39);
+      expect($rootScope.rate).toBe(3);
+    });
+
+    it('supports only arrow keys', function() {
+      $rootScope.rate = undefined;
+      $rootScope.$digest();
+
+      triggerKeyDown(36);
+      expect($rootScope.rate).toBe(undefined);
+
+      triggerKeyDown(41);
+      expect($rootScope.rate).toBe(undefined);
+    });
+
+    it('can get zero value but not negative', function() {
+      $rootScope.rate = 1;
+      $rootScope.$digest();
+
+      triggerKeyDown(37);
+      expect($rootScope.rate).toBe(0);
+
+      triggerKeyDown(37);
+      expect($rootScope.rate).toBe(0);
+    });
+
+    it('cannot get value above max', function() {
+      $rootScope.rate = 4;
+      $rootScope.$digest();
+
+      triggerKeyDown(38);
+      expect($rootScope.rate).toBe(5);
+
+      triggerKeyDown(38);
+      expect($rootScope.rate).toBe(5);
+    });
+  });
+
   describe('custom states', function() {
     beforeEach(inject(function() {
       $rootScope.classOn = 'icon-ok-sign';
       $rootScope.classOff = 'icon-ok-circle';
-      element = $compile('<rating value="rate" state-on="classOn" state-off="classOff"></rating>')($rootScope);
+      element = $compile('<rating ng-model="rate" state-on="classOn" state-off="classOff"></rating>')($rootScope);
       $rootScope.$digest();
     }));
 
@@ -145,12 +233,13 @@ describe('rating directive', function () {
         {stateOn: 'heart'},
         {stateOff: 'off'}
       ];
-      element = $compile('<rating value="rate" rating-states="states"></rating>')($rootScope);
+      element = $compile('<rating ng-model="rate" rating-states="states"></rating>')($rootScope);
       $rootScope.$digest();
     }));
 
-    it('should define number of icon elements', function () {
-      expect(getStars().length).toBe($rootScope.states.length);
+    it('should define number of icon elements', function() {
+      expect(getStars().length).toBe(4);
+      expect(element.attr('aria-valuemax')).toBe('4');
     });
 
     it('handles each icon', function() {
@@ -175,7 +264,7 @@ describe('rating directive', function () {
       ratingConfig.max = 10;
       ratingConfig.stateOn = 'on';
       ratingConfig.stateOff = 'off';
-      element = $compile('<rating value="rate"></rating>')($rootScope);
+      element = $compile('<rating ng-model="rate"></rating>')($rootScope);
       $rootScope.$digest();
     }));
     afterEach(inject(function(ratingConfig) {
@@ -183,12 +272,57 @@ describe('rating directive', function () {
       angular.extend(ratingConfig, originalConfig);
     }));
 
-    it('should change number of icon elements', function () {
+    it('should change number of icon elements', function() {
       expect(getStars().length).toBe(10);
     });
 
-    it('should change icon states', function () {
+    it('should change icon states', function() {
       expect(getState('on', 'off')).toEqual([true, true, true, true, true, false, false, false, false, false]);
+    });
+  });
+
+  describe('Default title', function() {
+    it('should return the default title for each star', function() {
+      expect(getTitles()).toEqual(['one', 'two', 'three', 'four', 'five']);
+    });
+  });
+
+  describe('shows different title when `max` attribute is greater than the titles array ', function() {
+    var originalConfig = {};
+    beforeEach(inject(function(ratingConfig) {
+      $rootScope.rate = 5;
+      angular.extend(originalConfig, ratingConfig);
+      ratingConfig.max = 10;
+      element = $compile('<rating ng-model="rate"></rating>')($rootScope);
+      $rootScope.$digest();
+    }));
+    afterEach(inject(function(ratingConfig) {
+      // return it to the original state
+      angular.extend(ratingConfig, originalConfig);
+    }));
+
+   it('should return the default title for each star', function() {
+      expect(getTitles()).toEqual(['one', 'two', 'three', 'four', 'five', '6', '7', '8', '9', '10']);
+    });
+  });
+
+  describe('shows custom titles ', function() {
+    it('should return the custom title for each star', function() {
+      $rootScope.titles = [44,45,46];
+      element = $compile('<rating ng-model="rate" titles="titles"></rating>')($rootScope);
+      $rootScope.$digest();
+      expect(getTitles()).toEqual(['44', '45', '46', '4', '5']);
+    });
+    it('should return the default title if the custom title is empty', function() {
+      $rootScope.titles = [];
+      element = $compile('<rating ng-model="rate" titles="titles"></rating>')($rootScope);
+      $rootScope.$digest();
+      expect(getTitles()).toEqual(['one', 'two', 'three', 'four', 'five']);
+    });
+   it('should return the default title if the custom title is not an array', function() {
+      element = $compile('<rating ng-model="rate" titles="test"></rating>')($rootScope);
+      $rootScope.$digest();
+      expect(getTitles()).toEqual(['one', 'two', 'three', 'four', 'five']);
     });
   });
 });

--- a/template/rating/rating.html
+++ b/template/rating/rating.html
@@ -1,4 +1,4 @@
-<span ng-mouseleave="reset()">
-  <i ng-repeat="r in range" ng-mouseenter="enter($index + 1)" ng-click="rate($index + 1)" class="fa"
-    ng-class="$index < val && (r.stateOn || 'fa-star') || (r.stateOff || 'fa-star-o')"></i>
+<span ng-mouseleave="reset()" ng-keydown="onKeydown($event)" tabindex="0" role="slider" aria-valuemin="0" aria-valuemax="{{range.length}}" aria-valuenow="{{value}}">
+    <span ng-repeat-start="r in range track by $index" class="show-for-sr">({{ $index < value ? '*' : ' ' }})</span>
+    <i ng-repeat-end ng-mouseenter="enter($index + 1)" ng-click="rate($index + 1)" class="fa" ng-class="$index < value && (r.stateOn || 'fa-star') || (r.stateOff || 'fa-star-o')" ng-attr-title="{{r.title}}" ></i>
 </span>


### PR DESCRIPTION
possibly adressing #238

foundation update due to .show-for-sr (zurb/foundation@7bb9efc5216840a81487a41f6ffd85c284a2c543)

BREAKING CHANGE: `rating` is now integrated with `ngModelController`.
 * `value` is replaced from `ng-model`.

  Before:

  `<rating value="rate" ...></rating>`

  After:

  `<rating ng-model="rate" ...></rating>`