### PR TITLE
fix(modal): should not get value property when modal is undefined

### DIFF
--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -257,17 +257,17 @@ angular.module('mm.foundation.modal', ['mm.foundation.transition'])
       };
 
       $modalStack.close = function (modalInstance, result) {
-        var modalWindow = openedWindows.get(modalInstance).value;
+        var modalWindow = openedWindows.get(modalInstance);
         if (modalWindow) {
-          modalWindow.deferred.resolve(result);
+          modalWindow.value.deferred.resolve(result);
           removeModalWindow(modalInstance);
         }
       };
 
       $modalStack.dismiss = function (modalInstance, reason) {
-        var modalWindow = openedWindows.get(modalInstance).value;
+        var modalWindow = openedWindows.get(modalInstance);
         if (modalWindow) {
-          modalWindow.deferred.reject(reason);
+          modalWindow.value.deferred.reject(reason);
           removeModalWindow(modalInstance);
         }
       };


### PR DESCRIPTION
Hi,

We found out that it will though exception by calling 'value' property when no modal instance exist. 
exception: TypeError: Cannot read property 'value' of undefined

Moreover, we found out there is similar issue for angular-bootstrap. Thus, the same fixed will fix in angualr-foundation as well.
https://github.com/angular-ui/bootstrap/pull/1972

Hope it help. Thank you
