### PR TITLE
fix(dropdownToggle): Dropdown not repositioned when window resized

### DIFF
--- a/src/dropdownToggle/dropdownToggle.js
+++ b/src/dropdownToggle/dropdownToggle.js
@@ -90,6 +90,16 @@ angular.module('mm.foundation.dropdownToggle', [ 'mm.foundation.position', 'mm.f
             }
           };
           $document.on('click', closeMenu);
+
+          angular.element($window).bind('resize', function() {
+            if (!!openElement) {
+              var left = $position.position(element).left;
+              if (dropdown.hasClass('right')) {
+                left = left - dropdownWidth + $position.position(element).width;
+              }
+              dropdown.css('left', left);
+            }
+          });
         }
       };
 

--- a/src/dropdownToggle/dropdownToggle.js
+++ b/src/dropdownToggle/dropdownToggle.js
@@ -62,7 +62,7 @@ angular.module('mm.foundation.dropdownToggle', [ 'mm.foundation.position', 'mm.f
             var left = Math.round(offset.left - parentOffset.left);
             var rightThreshold = $window.innerWidth - dropdownWidth - 8;
             if (left > rightThreshold) {
-                left = rightThreshold;
+                left = left - dropdownWidth + $position.position(element).width;
                 dropdown.removeClass('left').addClass('right');
             }
             css.left = left + 'px';


### PR DESCRIPTION
Related to https://github.com/pineconellc/angular-foundation/pull/258.

When window is resized, the open dropdown is not correctly repositioned below its toggle. Now the behaviour is correct either when the dropdown is left or right aligned.

Before:
![screen shot 2015-09-18 at 14 37 26](https://cloud.githubusercontent.com/assets/1845705/9959285/f9df7040-5e12-11e5-87d2-19d972ab5444.png)

After:
![screen shot 2015-09-18 at 14 38 00](https://cloud.githubusercontent.com/assets/1845705/9959294/04b45134-5e13-11e5-9dd3-ee4c1240b4cd.png)
