### PR TITLE
Add support for publishing to npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ bower_components
 npm-debug.log
 
 template/**/*.js
+
+/.idea

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "type": "git",
     "url": "git://github.com/pineconellc/angular-foundation.git"
   },
+  "main": "dist/mm-foundation-tpls-0.7.0-SNAPSHOT.min.js",
   "scripts": {
     "prepubluish": "grunt html2js && grunt build"
   },

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "type": "git",
     "url": "git://github.com/pineconellc/angular-foundation.git"
   },
+  "scripts": {
+    "prepubluish": "grunt html2js && grunt build"
+  },
   "devDependencies": {
     "karma": "~0.12.0",
     "karma-jasmine": "~0.1.0",


### PR DESCRIPTION
This pull request enables publishing `angular-foundation` to npm with a built dist and a porper main file for browserify support