### PR TITLE
feat(modal): ability to change the parent container for modals

### DIFF
--- a/src/modal/docs/readme.md
+++ b/src/modal/docs/readme.md
@@ -12,7 +12,7 @@ The `$modal` service has only one method: `open(options)` where available option
 * `backdrop` - controls presence of a backdrop. Allowed values: true (default), false (no backdrop), `'static'` - backdrop is present but modal window is not closed when clicking outside of the modal window.
 * `keyboard` - indicates whether the dialog should be closable by hitting the ESC key, defaults to true
 * `windowClass` - additional CSS class(es) to be added to a modal window template
-* `parent` - specify the container to put the modal element into. Limited to element tags without jQuery included.
+* `parent` - specify the container to put the modal element into. Default is 'body' and limited to element tags without jQuery included.
 
 The `open` method returns a modal instance, an object with the following properties:
 

--- a/src/modal/docs/readme.md
+++ b/src/modal/docs/readme.md
@@ -12,6 +12,7 @@ The `$modal` service has only one method: `open(options)` where available option
 * `backdrop` - controls presence of a backdrop. Allowed values: true (default), false (no backdrop), `'static'` - backdrop is present but modal window is not closed when clicking outside of the modal window.
 * `keyboard` - indicates whether the dialog should be closable by hitting the ESC key, defaults to true
 * `windowClass` - additional CSS class(es) to be added to a modal window template
+* `parent` - specify the container to put the modal element into. Limited to element tags without jQuery included.
 
 The `open` method returns a modal instance, an object with the following properties:
 

--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -213,13 +213,12 @@ angular.module('mm.foundation.modal', ['mm.foundation.transition'])
       });
 
       $modalStack.open = function (modalInstance, modal) {
-        var parentElem = modal.parent || 'body';
         modalInstance.options = {
           deferred: modal.deferred,
           modalScope: modal.scope,
           backdrop: modal.backdrop,
           keyboard: modal.keyboard,
-          parent: parentElem
+          parent: modal.parent
         };
         openedWindows.add(modalInstance, modalInstance.options);
 
@@ -377,7 +376,8 @@ angular.module('mm.foundation.modal', ['mm.foundation.transition'])
                 content: tplAndVars[0],
                 backdrop: modalOptions.backdrop,
                 keyboard: modalOptions.keyboard,
-                windowClass: modalOptions.windowClass
+                windowClass: modalOptions.windowClass,
+                parent: modalOptions.parent || 'body'
               });
 
             }, function resolveError(reason) {

--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -222,7 +222,7 @@ angular.module('mm.foundation.modal', ['mm.foundation.transition'])
         };
         openedWindows.add(modalInstance, modalInstance.options);
 
-        var parent = $document.find(parentElem).eq(0),
+        var parent = $document.find(modal.parent).eq(0),
             currBackdropIndex = backdropIndex();
 
         if (currBackdropIndex >= 0 && !backdropDomEl) {

--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -140,7 +140,7 @@ angular.module('mm.foundation.modal', ['mm.foundation.transition'])
       });
 
       function removeModalWindow(modalInstance) {
-        var body = $document.find('body').eq(0);
+        var parent = $document.find(modalInstance.options.parent).eq(0);
         var modalWindow = openedWindows.get(modalInstance).value;
 
         //clean up the stack
@@ -149,7 +149,7 @@ angular.module('mm.foundation.modal', ['mm.foundation.transition'])
         //remove window DOM element
         removeAfterAnimate(modalWindow.modalDomEl, modalWindow.modalScope, 300, function() {
           modalWindow.modalScope.$destroy();
-          body.toggleClass(OPENED_MODAL_CLASS, openedWindows.length() > 0);
+          parent.toggleClass(OPENED_MODAL_CLASS, openedWindows.length() > 0);
           checkRemoveBackdrop();
         });
       }
@@ -213,28 +213,30 @@ angular.module('mm.foundation.modal', ['mm.foundation.transition'])
       });
 
       $modalStack.open = function (modalInstance, modal) {
-
-        openedWindows.add(modalInstance, {
+        var parentElem = modal.parent || 'body';
+        modalInstance.options = {
           deferred: modal.deferred,
           modalScope: modal.scope,
           backdrop: modal.backdrop,
-          keyboard: modal.keyboard
-        });
+          keyboard: modal.keyboard,
+          parent: parentElem
+        };
+        openedWindows.add(modalInstance, modalInstance.options);
 
-        var body = $document.find('body').eq(0),
+        var parent = $document.find(parentElem).eq(0),
             currBackdropIndex = backdropIndex();
 
         if (currBackdropIndex >= 0 && !backdropDomEl) {
           backdropScope = $rootScope.$new(true);
           backdropScope.index = currBackdropIndex;
           backdropDomEl = $compile('<div modal-backdrop></div>')(backdropScope);
-          body.append(backdropDomEl);
+          parent.append(backdropDomEl);
         }
 
         // Create a faux modal div just to measure its
         // distance to top
         var faux = angular.element('<div class="reveal-modal" style="z-index:-1""></div>');
-        body.append(faux[0]);
+        parent.append(faux[0]);
         var marginTop = parseInt(getComputedStyle(faux[0]).top) || 0;
         faux.remove();
 
@@ -252,8 +254,8 @@ angular.module('mm.foundation.modal', ['mm.foundation.transition'])
 
         var modalDomEl = $compile(angularDomEl)(modal.scope);
         openedWindows.top().value.modalDomEl = modalDomEl;
-        body.append(modalDomEl);
-        body.addClass(OPENED_MODAL_CLASS);
+        parent.append(modalDomEl);
+        parent.addClass(OPENED_MODAL_CLASS);
       };
 
       $modalStack.close = function (modalInstance, result) {

--- a/src/modal/test/modal.spec.js
+++ b/src/modal/test/modal.spec.js
@@ -122,6 +122,14 @@ describe('$modal', function () {
         };
 
         return backdropDomEls.length === 1;
+      },
+      toHaveModalOpenInOtherParent: function(parentSelector){
+        var modalElem = this.actual.find(parentSelector + ' > .reveal-modal');
+        this.message = function() {
+          return 'Expected modal to be a parent of: ' + parentSelector;
+        };
+
+        return modalElem.length === 1;
       }
     });
   }));
@@ -424,6 +432,24 @@ describe('$modal', function () {
           scope: $scope
         });
         expect($document).toHaveModalOpenWithContent('Content from custom scope', 'div');
+      });
+    });
+
+    describe('parent', function () {
+      beforeEach(function(){
+        $document.find('body').append('<div id="modal-container"></div>');
+      });
+
+      it('should use an element other than body as the parent if provided', function () {
+        open({
+          template: '<div>Parent other than body</div>',
+          parent: '#modal-container'
+        });
+        expect($document).toHaveModalOpenInOtherParent('#modal-container');
+      });
+
+      afterEach(function(){
+        $document.find('body').find('#modal-container').remove();
       });
     });
 

--- a/src/modal/test/modal.spec.js
+++ b/src/modal/test/modal.spec.js
@@ -437,19 +437,19 @@ describe('$modal', function () {
 
     describe('parent', function () {
       beforeEach(function(){
-        $document.find('body').append('<div id="modal-container"></div>');
+        $document.find('body').append('<modal><modal>');
       });
 
       it('should use an element other than body as the parent if provided', function () {
         open({
           template: '<div>Parent other than body</div>',
-          parent: '#modal-container'
+          parent: 'modal'
         });
-        expect($document).toHaveModalOpenInOtherParent('#modal-container');
+        expect($document).toHaveModalOpenInOtherParent('modal');
       });
 
       afterEach(function(){
-        $document.find('body').find('#modal-container').remove();
+        $document.find('body').find('modal').remove();
       });
     });
 


### PR DESCRIPTION
We are currently in need of changing the target for the modal parent from body to another div. 

I have added the functionality by adding the option "parent" to the modal options that by default is still 'body'

This also allows the users to use jquery selectors if they are including jquery. However, the test i wrote for it utilizes a <modal></modal> pseudo-tag which should also work in jqlite. Existing functionality should remain backwards compatible while expanding options for those who need it.