### PR TITLE
fix and tweak to dropdown toggle

### DIFF
--- a/src/dropdownToggle/dropdownToggle.js
+++ b/src/dropdownToggle/dropdownToggle.js
@@ -64,7 +64,7 @@ angular.module('mm.foundation.dropdownToggle', [ 'mm.foundation.position', 'mm.f
             var left = Math.round(offset.left - parentOffset.left);
             var rightThreshold = $window.innerWidth - dropdownWidth - 8;
             if (left > rightThreshold) {
-                left = rightThreshold;
+                left = offset.left - parentOffset.left - dropdownWidth + offset.width;
                 dropdown.removeClass('left').addClass('right');
             }
             css.left = left + 'px';

--- a/src/dropdownToggle/dropdownToggle.js
+++ b/src/dropdownToggle/dropdownToggle.js
@@ -66,6 +66,8 @@ angular.module('mm.foundation.dropdownToggle', [ 'mm.foundation.position', 'mm.f
             if (left > rightThreshold) {
                 left = offset.left - parentOffset.left - dropdownWidth + offset.width;
                 dropdown.removeClass('left').addClass('right');
+            } else {
+                dropdown.removeClass('right').addClass('left');
             }
             css.left = left + 'px';
             css.position = null;


### PR DESCRIPTION
One commit to give better (in my opinion) alignment for dropdown toggle when past the right threshold.

Second commit fixes a bug where the pip would get stuck at the right once the dropdown toggle was first displayed past the right threshold (I reuse the same dropdown at various positions on the screen, and the pip would get stuck at the right after first being shown there).
