### PR TITLE
fix(interchange): adjust test to accomodate newer browsers

### DIFF
--- a/src/interchange/test/interchange.spec.js
+++ b/src/interchange/test/interchange.spec.js
@@ -171,11 +171,11 @@ describe("interchange", function () {
         $compile(element)(scope);
         scope.$digest();
         expect(element.attr('src')).toBeUndefined();
-        expect(element.attr('style')).toMatch(/background-image:\ ?url\([a-zA-Z0-9\.\\\/\@\:]*default\.jpg\)/);
+        expect(element.attr('style')).toMatch(/background-image:\ ?url\(\"?[a-zA-Z0-9\.\\\/\@\:]*default\.jpg\"?\)/);
 
         matchMediaMock = 'only screen and (min-width:64.063em)';
         window.dispatchEvent(new Event('resize'));
-        expect(element.attr('style')).toMatch(/background-image:\ ?url\([a-zA-Z0-9\.\\\/\@\:]*large\.TIFF\)/);
+        expect(element.attr('style')).toMatch(/background-image:\ ?url\(\"?[a-zA-Z0-9\.\\\/\@\:]*large\.TIFF\"?\)/);
       });
 
       it('should not change the content when the interchange is for dynamic background', function () {


### PR DESCRIPTION
Found the issue with not being able to get this test to pass locally, it's that I have Chrome v47.x and Semaphore uses Chrome v46.x.

Seems the newer version of Chrome adds quotations around the background-image url reference.

You can see for yourself on this jsfiddle - http://jsfiddle.net/alindber/y0qxz971/
