### PR TITLE
Fixed issue where disabled class is not applied to tabs.

### DIFF
--- a/template/tabs/tab.html
+++ b/template/tabs/tab.html
@@ -1,3 +1,3 @@
-<dd ng-class="{active: active}">
+<dd ng-class="{active: active, disabled: disabled}">
   <a ng-click="select()" tab-heading-transclude>{{heading}}</a>
 </dd>

--- a/template/tabs/tabset.html
+++ b/template/tabs/tabset.html
@@ -3,7 +3,7 @@
   <div class="tabs-content" ng-class="{'vertical': vertical}">
     <div class="content" 
       ng-repeat="tab in tabs" 
-      ng-class="{active: tab.active}">
+      ng-class="{active: tab.active, disabled: tab.disabled}">
       <div tab-content-transclude="tab"></div>
     </div>
   </div>


### PR DESCRIPTION
Tabs are disabled navigation-wise but not visually because the disabled class is not being applied. Adding the disabled property to the templates fixes this issue.