### PR TITLE
fix(topbar): disallow scope.apply when topbar is not sticky

### DIFF
--- a/src/topbar/test/topbar.spec.js
+++ b/src/topbar/test/topbar.spec.js
@@ -158,4 +158,43 @@ describe('topbar directive', function() {
       expect(containerElement.hasClass('fixed')).toBe(false);
     });
   });
+
+  describe('onScroll', function() {
+    var scope, elm;
+
+    beforeEach(inject(function($compile, $rootScope) {
+      elm = $compile('<top-bar></top-bar>')($rootScope);
+      $rootScope.$digest();
+      scope = elm.isolateScope();
+      scope.$apply = jasmine.createSpy('$apply');
+    }));
+
+    describe('when both stickyTopbar and isSticky are true', function() {
+      it('does not invoke scope.$apply', function() {
+        scope.stickyTopbar = true;
+        scope.isSticky = jasmine.createSpy('isSticky').andReturn(true);
+        angular.element($window).triggerHandler('scroll');
+        expect(scope.$apply).toHaveBeenCalled();
+      });
+    });
+
+    describe('when either stickyTopbar or isSticky is false', function() {
+      it('does not invoke scope.$apply', function () {
+        scope.stickyTopbar = false;
+        scope.isSticky = jasmine.createSpy('isSticky').andReturn(false);
+        angular.element($window).triggerHandler('scroll');
+        expect(scope.$apply).not.toHaveBeenCalled();
+
+        scope.stickyTopbar = true;
+        scope.isSticky = jasmine.createSpy('isSticky').andReturn(false);
+        angular.element($window).triggerHandler('scroll');
+        expect(scope.$apply).not.toHaveBeenCalled();
+
+        scope.stickyTopbar = false;
+        scope.isSticky = jasmine.createSpy('isSticky').andReturn(true);
+        angular.element($window).triggerHandler('scroll');
+        expect(scope.$apply).not.toHaveBeenCalled();
+      });
+    });
+  });
 });

--- a/src/topbar/topbar.js
+++ b/src/topbar/topbar.js
@@ -147,7 +147,7 @@ angular.module("mm.foundation.topbar", ['mm.foundation.mediaQueries'])
 
         var updateStickyPositioning = function() {
           if (!scope.stickyTopbar || !scope.isSticky()) {
-            return;
+            return false;
           }
 
           var distance = stickyoffset;
@@ -159,6 +159,7 @@ angular.module("mm.foundation.topbar", ['mm.foundation.mediaQueries'])
             topbarContainer.removeClass('fixed');
             body.css('padding-top', '');
           }
+          return true;
         };
 
         var onResize = function() {
@@ -181,8 +182,10 @@ angular.module("mm.foundation.topbar", ['mm.foundation.mediaQueries'])
         };
 
         var onScroll = function() {
-          updateStickyPositioning();
-          scope.$apply();
+          var updated = updateStickyPositioning();
+          if (updated === true) {
+            scope.$apply();
+          }
         };
 
         scope.toggle = function(on) {


### PR DESCRIPTION
**What kind of change does this PR introduce?**: performance improvement
**What is the current behavior?**:
I noticed this when I was doing profiling on my application:
![screen shot 2016-06-09 at 3 12 47 pm](https://cloud.githubusercontent.com/assets/746239/15947359/1924503e-2e69-11e6-9651-df4d5895df61.png)
Currently if the top bar is not specified as sticky in anyway it still tries to call scope.$apply, which can potentially slow down the application. In my case, the application is relatively large, and the slowness starts to get noticeable.
**What is the new behavior?**: it doesn't run scope.apply if topBar is not sticky
**Does this PR introduce a breaking change?:** no

thanks!
