### PR TITLE
fix(typeahead): Set parse key to valid when selecting exact match

### DIFF
--- a/src/typeahead/test/typeahead.spec.js
+++ b/src/typeahead/test/typeahead.spec.js
@@ -599,6 +599,16 @@ describe('typeahead tests', function () {
 
       expect(element).toBeOpenWithActive(2, 0);
     });
+
+    it('should set \'parse\' key as valid when selecting a perfect match and not editable', function () {
+      var element = prepareInputEl('<div ng-form="test"><input name="typeahead" ng-model="result" typeahead="state as state.name for state in states | filter:$viewValue" typeahead-editable="false"></div>');
+      var inputEl = findInput(element);
+
+      changeInputValueTo(element, 'Alaska');
+      triggerKeyDown(element, 13);
+
+      expect($scope.test.typeahead.$error.parse).toBeUndefined();
+    });
   });
 
   describe('input formatting', function () {

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -212,6 +212,7 @@ angular.module('mm.foundation.typeahead', ['mm.foundation.position', 'mm.foundat
         model = parserResult.modelMapper(originalScope, locals);
         $setModelValue(originalScope, model);
         modelCtrl.$setValidity('editable', true);
+        modelCtrl.$setValidity('parse', true);
 
         onSelectCallback(originalScope, {
           $item: item,


### PR DESCRIPTION
This fixes a bug in typeahead where if you set `typeahead-editable="false"` and then type an exact match into the typeahead and select it, the `parse` error key does not get reset, and as a result the form looks invalid.  This issue was documented in angular-ui/bootstrap#3166 and fixed in https://github.com/angular-ui/bootstrap/commit/c0a9c707903fa3dfc662887cd348ee2b0bf13f85.  I simply ported the exact code and unit test into angular-foundation.